### PR TITLE
支持 sandbox 以及其他一些微小的修改

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,15 @@ Or install it yourself as:
 
 ## Usage
 ```ruby
+# setting
+WechatPay::Config.appid        = 'appid'
+WechatPay::Config.mch_id       = 'mch_id'
+WechatPay::Config.key          = 'api_key'
+WechatPay::Config.secret       = 'xxxxxx'
+WechatPay::Config.sandbox      = false # true | false
+WechatPay::Config.sandbox_key  = 'sandbox api_key'
+WechatPay::Config.http_headers = { user_agent: 'WwchatPay-API-Client/1.0' }
+
 #prepare the request.
       request_handler = WechatPay::API.unified_order({
         out_trade_no: '303024032043',
@@ -34,13 +43,15 @@ Or install it yourself as:
 #some example 
 return_msg = respond.return_code #=> 'SUCCESS' or maybe 'FAIL'
 return_code = respond.return_msg
+
+respond.validate!  # raise error if return_code != 'success' or result_code != 'success'
 ```
 	
 For more detailed params and variale requirement and list, please refer to WxPay offical documentation.
 
 ## Contributing
 
-1. Fork it ( https://github.com/[my-github-username]/wechat_pay/fork )
+1. Fork it ( https://github.com/stillwyw/wechat_pay/fork )
 2. Create your feature branch (`git checkout -b my-new-feature`)
 3. Commit your changes (`git commit -am 'Add some feature'`)
 4. Push to the branch (`git push origin my-new-feature`)

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ WechatPay::Config.mch_id       = 'mch_id'
 WechatPay::Config.key          = 'api_key'
 WechatPay::Config.secret       = 'xxxxxx'
 WechatPay::Config.sandbox      = false # true | false
-WechatPay::Config.sandbox_key  = 'sandbox api_key'
+WechatPay::Config.sandbox_key  = 'sandbox api_key' # post the http request by production api_key : WechatPay::Signature::get_sandbox_key_from_api
 WechatPay::Config.http_headers = { user_agent: 'WwchatPay-API-Client/1.0' }
 
 #prepare the request.

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ WechatPay::Config.key          = 'api_key'
 WechatPay::Config.secret       = 'xxxxxx'
 WechatPay::Config.sandbox      = false # true | false
 WechatPay::Config.sandbox_key  = 'sandbox api_key' # post the http request by production api_key : WechatPay::Signature::get_sandbox_key_from_api
-WechatPay::Config.http_headers = { user_agent: 'WwchatPay-API-Client/1.0' }
+WechatPay::Config.http_headers = { user_agent: 'WechatPay-API-Client/1.0' }
 
 #prepare the request.
       request_handler = WechatPay::API.unified_order({

--- a/lib/wechat_pay.rb
+++ b/lib/wechat_pay.rb
@@ -13,7 +13,7 @@ require 'wechat_pay/error'
 module WechatPay
   module Config
     class << self
-      attr_accessor :appid, :mch_id, :key, :secret, :http_headers, :sandbox, :sandbox_key
+      attr_accessor :appid, :mch_id, :key, :secret, :http_headers, :sandbox
     end
   end
   

--- a/lib/wechat_pay.rb
+++ b/lib/wechat_pay.rb
@@ -7,6 +7,7 @@ require 'wechat_pay/signature'
 require 'wechat_pay/notify_handler'
 require 'wechat_pay/respond'
 require 'wechat_pay/request'
+require 'wechat_pay/get_sign_key_request'
 require "wechat_pay/version"
 require 'wechat_pay/error'
 

--- a/lib/wechat_pay.rb
+++ b/lib/wechat_pay.rb
@@ -19,7 +19,7 @@ module WechatPay
   
   module API
     PAYMENT_TYPES = ['NATIVE', 'JSAPI', 'APP']
-    URL_BASE = "https://api.mch.weixin.qq.com"
+    URI_BASE = "https://api.mch.weixin.qq.com"
     
     def self.root_path()
       if WechatPay::Config.sandbox

--- a/lib/wechat_pay.rb
+++ b/lib/wechat_pay.rb
@@ -21,7 +21,7 @@ module WechatPay
     PAYMENT_TYPES = ['NATIVE', 'JSAPI', 'APP']
     URI_BASE = "https://api.mch.weixin.qq.com"
     
-    def self.root_path()
+    def self.root_path
       if WechatPay::Config.sandbox
         '/sandboxnew/'
       else
@@ -31,7 +31,7 @@ module WechatPay
 
     # unified order 
     def self.unified_order(options={})
-      url = URI_BASE + root_path(sandbox) + "pay/unifiedorder"
+      url = URI_BASE + root_path + "pay/unifiedorder"
       
       #these are must have values.
       [:body, :out_trade_no, :total_fee, :spbill_create_ip, :notify_url, :trade_type].each do |attr|
@@ -43,19 +43,19 @@ module WechatPay
     
     # order status querying 
     def self.order_query(options={})
-      url = URI_BASE + root_path(sandbox) + "pay/orderquery";
+      url = URI_BASE + root_path + "pay/orderquery";
       raise WechatPay::Error.new  "At least provide one of both :transaction_id and :out_trade_no for order_query()" unless options[:transaction_id] or options[:out_trade_no]
       WechatPay::Request.new(url, options)
     end
     
     def self.close_order(options={})
-      url = URI_BASE + root_path(sandbox) + "pay/closeorder";
+      url = URI_BASE + root_path + "pay/closeorder";
       raise  WechatPay::Error.new "At least provide one of both :transaction_id and :out_trade_no for close_order()" unless options[:transaction_id] or options[:out_trade_no]
       WechatPay::Request.new(url, options)
     end
     
     def self.refund(options={})
-      url = URI_BASE + root_path(sandbox) + "secapi/pay/refund";
+      url = URI_BASE + root_path + "secapi/pay/refund";
       raise "At least provide one of both :transaction_id and :out_trade_no!" unless options[:transaction_id] or options[:out_trade_no]
       [:out_refund_no, :total_fee, :refund_fee, :op_user_id].each do |attr|
         raise  WechatPay::Error.new "No #{attr} is provided for refund()" unless options[attr]
@@ -64,28 +64,28 @@ module WechatPay
     end
     
     def self.refund_query(options={})
-      url = URI_BASE + root_path(sandbox) + "pay/refundquery";
+      url = URI_BASE + root_path + "pay/refundquery";
       raise  WechatPay::Error.new "At least provide one of :transaction_id, :out_trade_no, :out_refund_no, :refund_id for refund_query()" unless options[:transaction_id] or options[:out_trade_no] or options[:out_refund_no] or options[:refund_id]
       WechatPay::Request.new(url, options)
     end
     
     def self.download_bill(options={})
-      url = URI_BASE + root_path(sandbox) + "pay/downloadbill"
+      url = URI_BASE + root_path + "pay/downloadbill"
       WechatPay::Request.new(url, options)
     end
     
     def self.micropay(options={})
-      url = URI_BASE + root_path(sandbox) + "pay/micropay"
+      url = URI_BASE + root_path + "pay/micropay"
       WechatPay::Request.new(url, options)
     end
     
     def self.reverse(options={})
-      url = URI_BASE + root_path(sandbox) + "secapi/pay/reverse"
+      url = URI_BASE + root_path + "secapi/pay/reverse"
       WechatPay::Request.new(url, options)
     end
     
     def self.report(options={})
-      url = URI_BASE + root_path(sandbox) + "payitil/report"
+      url = URI_BASE + root_path + "payitil/report"
       WechatPay::Request.new(url, options)
     end
     

--- a/lib/wechat_pay.rb
+++ b/lib/wechat_pay.rb
@@ -14,7 +14,7 @@ require 'wechat_pay/error'
 module WechatPay
   module Config
     class << self
-      attr_accessor :appid, :mch_id, :key, :secret, :http_headers, :sandbox
+      attr_accessor :appid, :mch_id, :key, :secret, :http_headers, :sandbox, :sandbox_key
     end
   end
   

--- a/lib/wechat_pay.rb
+++ b/lib/wechat_pay.rb
@@ -92,7 +92,7 @@ module WechatPay
 
     def self.sandbox_api_key()
       url = URI_BASE + "/sandboxnew/pay/getsignkey"
-      WechatPay::GetSignKeyRequest.new(url, options)
+      WechatPay::GetSignKeyRequest.new(url, {})
     end
 
     def self.bizpayurl(options={})

--- a/lib/wechat_pay.rb
+++ b/lib/wechat_pay.rb
@@ -13,7 +13,7 @@ require 'wechat_pay/error'
 module WechatPay
   module Config
     class << self
-      attr_accessor :appid, :mch_id, :key, :secret
+      attr_accessor :appid, :mch_id, :key, :secret, :http_headers
     end
   end
   

--- a/lib/wechat_pay.rb
+++ b/lib/wechat_pay.rb
@@ -13,7 +13,7 @@ require 'wechat_pay/error'
 module WechatPay
   module Config
     class << self
-      attr_accessor :appid, :mch_id, :key, :secret, :http_headers, :sandbox
+      attr_accessor :appid, :mch_id, :key, :secret, :http_headers, :sandbox, :sandbox_key
     end
   end
   

--- a/lib/wechat_pay.rb
+++ b/lib/wechat_pay.rb
@@ -13,16 +13,25 @@ require 'wechat_pay/error'
 module WechatPay
   module Config
     class << self
-      attr_accessor :appid, :mch_id, :key, :secret, :http_headers
+      attr_accessor :appid, :mch_id, :key, :secret, :http_headers, :sandbox
     end
   end
   
   module API
     PAYMENT_TYPES = ['NATIVE', 'JSAPI', 'APP']
+    URL_BASE = "https://api.mch.weixin.qq.com"
     
+    def self.root_path()
+      if WechatPay::Config.sandbox
+        '/sandboxnew/'
+      else
+        '/'
+      end
+    end
+
     # unified order 
     def self.unified_order(options={})
-      url = "https://api.mch.weixin.qq.com/pay/unifiedorder"
+      url = URI_BASE + root_path(sandbox) + "pay/unifiedorder"
       
       #these are must have values.
       [:body, :out_trade_no, :total_fee, :spbill_create_ip, :notify_url, :trade_type].each do |attr|
@@ -34,19 +43,19 @@ module WechatPay
     
     # order status querying 
     def self.order_query(options={})
-      url = "https://api.mch.weixin.qq.com/pay/orderquery";
+      url = URI_BASE + root_path(sandbox) + "pay/orderquery";
       raise WechatPay::Error.new  "At least provide one of both :transaction_id and :out_trade_no for order_query()" unless options[:transaction_id] or options[:out_trade_no]
       WechatPay::Request.new(url, options)
     end
     
     def self.close_order(options={})
-      url = "https://api.mch.weixin.qq.com/pay/closeorder";
+      url = URI_BASE + root_path(sandbox) + "pay/closeorder";
       raise  WechatPay::Error.new "At least provide one of both :transaction_id and :out_trade_no for close_order()" unless options[:transaction_id] or options[:out_trade_no]
       WechatPay::Request.new(url, options)
     end
     
     def self.refund(options={})
-      url = "https://api.mch.weixin.qq.com/secapi/pay/refund";
+      url = URI_BASE + root_path(sandbox) + "secapi/pay/refund";
       raise "At least provide one of both :transaction_id and :out_trade_no!" unless options[:transaction_id] or options[:out_trade_no]
       [:out_refund_no, :total_fee, :refund_fee, :op_user_id].each do |attr|
         raise  WechatPay::Error.new "No #{attr} is provided for refund()" unless options[attr]
@@ -55,28 +64,28 @@ module WechatPay
     end
     
     def self.refund_query(options={})
-      url = "https://api.mch.weixin.qq.com/pay/refundquery";
+      url = URI_BASE + root_path(sandbox) + "pay/refundquery";
       raise  WechatPay::Error.new "At least provide one of :transaction_id, :out_trade_no, :out_refund_no, :refund_id for refund_query()" unless options[:transaction_id] or options[:out_trade_no] or options[:out_refund_no] or options[:refund_id]
       WechatPay::Request.new(url, options)
     end
     
     def self.download_bill(options={})
-      url = "https://api.mch.weixin.qq.com/pay/downloadbill"
+      url = URI_BASE + root_path(sandbox) + "pay/downloadbill"
       WechatPay::Request.new(url, options)
     end
     
     def self.micropay(options={})
-      url = "https://api.mch.weixin.qq.com/pay/micropay"
+      url = URI_BASE + root_path(sandbox) + "pay/micropay"
       WechatPay::Request.new(url, options)
     end
     
     def self.reverse(options={})
-      url = "https://api.mch.weixin.qq.com/secapi/pay/reverse"
+      url = URI_BASE + root_path(sandbox) + "secapi/pay/reverse"
       WechatPay::Request.new(url, options)
     end
     
     def self.report(options={})
-      url = "https://api.mch.weixin.qq.com/payitil/report"
+      url = URI_BASE + root_path(sandbox) + "payitil/report"
       WechatPay::Request.new(url, options)
     end
     

--- a/lib/wechat_pay.rb
+++ b/lib/wechat_pay.rb
@@ -88,7 +88,12 @@ module WechatPay
       url = URI_BASE + root_path + "payitil/report"
       WechatPay::Request.new(url, options)
     end
-    
+
+    def self.sandbox_api_key()
+      url = URI_BASE + "/sandboxnew/pay/getsignkey"
+      WechatPay::GetSignKeyRequest.new(url, options)
+    end
+
     def self.bizpayurl(options={})
       WechatPay::Request.new(url, options)
     end

--- a/lib/wechat_pay/error.rb
+++ b/lib/wechat_pay/error.rb
@@ -1,7 +1,4 @@
 module WechatPay
   class Error < StandardError
-    def initialize
-      super
-    end
   end
 end

--- a/lib/wechat_pay/get_sign_key_request.rb
+++ b/lib/wechat_pay/get_sign_key_request.rb
@@ -1,0 +1,38 @@
+module WechatPay
+  class GetSignKeyRequest < Request
+    def initialize(url, options)
+      @url = url
+      @params = options
+      @params[:mch_id] = options[:mch_id] || WechatPay::Config.mch_id
+      @params[:nonce_str] = options[:nonce_str] || SecureRandom.urlsafe_base64(16)
+      @params[:sign] = WechatPay::Signature.sign(@params)
+      @out_xml = @params.to_xml(:root => :xml, :dasherize => false)
+    end
+
+    def send
+      headers = WechatPay::Config.http_headers.dup || {}
+      headers[:content_type] = 'application/xml'
+
+      requret = HTTP.with_headers(headers)
+      self.parse(requret.post(@url, body: @out_xml))
+    end
+
+    def check_sign(hash)
+      hash = hash['xml']
+      fail "WechatPay::GetSignKeyRequest fail: #{hash.inspect}" if hash['return_code'] == 'FAIL'
+
+      signature = hash.delete('sign')
+
+      str = hash.sort.map{|m| m.join("=")}.join("&")
+      str += "&key=#{WechatPay::Config.key}"
+      expect_sign = Digest::MD5.hexdigest(str).upcase
+
+      raise WechatPay::Error.new "Signature does not match! The signature from wechat is #{expect_sign} the one you got is #{signature}" unless signature.upcase == expect_sign.upcase
+    end
+
+    def parse(res)
+      self.check_sign(@respond_hash = Hash.from_xml(res))
+      WechatPay::Respond.new @respond_hash['xml']
+    end
+  end
+end

--- a/lib/wechat_pay/get_sign_key_request.rb
+++ b/lib/wechat_pay/get_sign_key_request.rb
@@ -5,33 +5,12 @@ module WechatPay
       @params = options
       @params[:mch_id] = options[:mch_id] || WechatPay::Config.mch_id
       @params[:nonce_str] = options[:nonce_str] || SecureRandom.urlsafe_base64(16)
-      @params[:sign] = WechatPay::Signature.sign(@params)
+      @params[:sign] = WechatPay::Signature.sign(@params, WechatPay::Config.key)
       @out_xml = @params.to_xml(:root => :xml, :dasherize => false)
     end
 
-    def send
-      headers = WechatPay::Config.http_headers.dup || {}
-      headers[:content_type] = 'application/xml'
-
-      requret = HTTP.with_headers(headers)
-      self.parse(requret.post(@url, body: @out_xml))
-    end
-
-    def check_sign(hash)
-      hash = hash['xml']
-      fail "WechatPay::GetSignKeyRequest fail: #{hash.inspect}" if hash['return_code'] == 'FAIL'
-
-      signature = hash.delete('sign')
-
-      str = hash.sort.map{|m| m.join("=")}.join("&")
-      str += "&key=#{WechatPay::Config.key}"
-      expect_sign = Digest::MD5.hexdigest(str).upcase
-
-      raise WechatPay::Error.new "Signature does not match! The signature from wechat is #{expect_sign} the one you got is #{signature}" unless signature.upcase == expect_sign.upcase
-    end
-
     def parse(res)
-      self.check_sign(@respond_hash = Hash.from_xml(res))
+      @respond_hash = Hash.from_xml(res)
       WechatPay::Respond.new @respond_hash['xml']
     end
   end

--- a/lib/wechat_pay/request.rb
+++ b/lib/wechat_pay/request.rb
@@ -17,7 +17,7 @@ module WechatPay
       headers = WechatPay::Config.http_headers.dup || {}
       headers[:content_type] = 'application/xml'
       
-      requret = HTTP.with_headers(headers)
+      requret = HTTP.headers(headers)
       self.parse(requret.post(@url, body: @out_xml))
     end
     

--- a/lib/wechat_pay/request.rb
+++ b/lib/wechat_pay/request.rb
@@ -17,7 +17,7 @@ module WechatPay
       headers = WechatPay::Config.http_headers.dup || {}
       headers[:content_type] = 'application/xml'
       
-      requret = HTTP.with_headers(user_agent: "dzg", content_type: 'application/xml')
+      requret = HTTP.with_headers(headers)
       self.parse(requret.post(@url, body: @out_xml))
     end
     

--- a/lib/wechat_pay/request.rb
+++ b/lib/wechat_pay/request.rb
@@ -14,7 +14,11 @@ module WechatPay
     end
     
     def send
-      self.parse(HTTP.post(@url, body: @out_xml))
+      headers = WechatPay::Config.http_headers.dup || {}
+      headers[:content_type] = 'application/xml'
+      
+      requret = HTTP.with_headers(user_agent: "dzg", content_type: 'application/xml')
+      self.parse(requret.post(@url, body: @out_xml))
     end
     
     def parse(res)

--- a/lib/wechat_pay/respond.rb
+++ b/lib/wechat_pay/respond.rb
@@ -2,10 +2,25 @@ module WechatPay
   class Respond < OpenStruct
     attr_reader :xml, :hash
 
+    SUCCESS_STATUS = 'SUCCESS'
+    
     def initialize(respond_hash)
       @xml = respond_hash.to_xml
       @hash = respond_hash
       super(respond_hash)
+    end
+    
+    def return_code_success?
+      self.return_code == SUCCESS_STATUS
+    end
+
+    def result_code_success?
+      self.result_code == SUCCESS_STATUS
+    end
+
+    def validate!
+      fail "return_code is not success (#{self.return_code}): #{self.return_msg}" unless return_code_success?
+      fail "result_code is not success (#{self.result_code}): #{self.err_code}:#{self.err_code_des}" unless result_code_success?
     end
   end
 end

--- a/lib/wechat_pay/signature.rb
+++ b/lib/wechat_pay/signature.rb
@@ -1,9 +1,7 @@
 module WechatPay
   module Signature
     def self.api_key
-      return WechatPay::Config.key unless WechatPay::Config.sandbox
-
-      get_signkey_from_sandbox
+      WechatPay::Config.sandbox ? WechatPay::Config.sandbox_key : WechatPay::Config.key
     end
 
     def self.sign(hash, key = self.api_key)
@@ -21,7 +19,9 @@ module WechatPay
       raise WechatPay::Error.new "Signature does not match! The signature from wechat is #{signature} the one you got is #{sign(hash)}" unless signature.upcase == sign(hash).upcase
     end
 
-    def self.get_signkey_from_sandbox
+    def self.get_sandbox_key_from_api
+      return unless WechatPay::Config.sandbox
+
       response = WechatPay::API.sandbox_api_key.send
       response.sandbox_signkey
     end

--- a/lib/wechat_pay/signature.rb
+++ b/lib/wechat_pay/signature.rb
@@ -1,7 +1,11 @@
 module WechatPay
-  module Signature    
+  module Signature
+    def self.current_key
+      WechatPay::Config.sandbox ? WechatPay::Config.sandbox_key : WechatPay::Config.key
+    end
+
     def self.sign(hash)
-      key = WechatPay::Config.key
+      key = current_key
       str = hash.sort.map{|m| m.join("=")}.join("&")
       str += "&key=#{key}"
       Digest::MD5.hexdigest(str)      
@@ -9,7 +13,7 @@ module WechatPay
     
     def self.check_sign(hash)
       hash = hash['xml'] || hash[:xml] || hash
-      key = WechatPay::Config.key
+      key = current_key
       return if (hash[:return_code] || hash['return_code']) == 'FAIL'
       signature = hash[:sign] || hash['sign']
       hash.delete(:sign)

--- a/lib/wechat_pay/signature.rb
+++ b/lib/wechat_pay/signature.rb
@@ -8,9 +8,9 @@ module WechatPay
       key = current_key
       str = hash.sort.map{|m| m.join("=")}.join("&")
       str += "&key=#{key}"
-      Digest::MD5.hexdigest(str)      
+      Digest::MD5.hexdigest(str).upcase
     end
-    
+
     def self.check_sign(hash)
       hash = hash['xml'] || hash[:xml] || hash
       key = current_key

--- a/lib/wechat_pay/signature.rb
+++ b/lib/wechat_pay/signature.rb
@@ -1,11 +1,12 @@
 module WechatPay
   module Signature
-    def self.current_key
-      WechatPay::Config.sandbox ? WechatPay::Config.sandbox_key : WechatPay::Config.key
+    def self.api_key
+      return WechatPay::Config.key unless WechatPay::Config.sandbox
+
+      get_signkey_from_sandbox
     end
 
-    def self.sign(hash)
-      key = current_key
+    def self.sign(hash, key = self.api_key)
       str = hash.sort.map{|m| m.join("=")}.join("&")
       str += "&key=#{key}"
       Digest::MD5.hexdigest(str).upcase
@@ -13,12 +14,16 @@ module WechatPay
 
     def self.check_sign(hash)
       hash = hash['xml'] || hash[:xml] || hash
-      key = current_key
       return if (hash[:return_code] || hash['return_code']) == 'FAIL'
       signature = hash[:sign] || hash['sign']
       hash.delete(:sign)
       hash.delete('sign')
       raise WechatPay::Error.new "Signature does not match! The signature from wechat is #{signature} the one you got is #{sign(hash)}" unless signature.upcase == sign(hash).upcase
+    end
+
+    def self.get_signkey_from_sandbox
+      response = WechatPay::API.sandbox_api_key.send
+      response.sandbox_signkey
     end
   end
 end

--- a/wechat_pay.gemspec
+++ b/wechat_pay.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 
-  spec.add_dependency 'http'
+  spec.add_dependency 'http', '>= 1.0'
   spec.add_dependency 'builder'
   spec.add_dependency 'activesupport'
 


### PR DESCRIPTION
* 目前微信的 sandbox 环境有不少坑，但勉强可以用来在开发阶段测试
    * 参考:  [sandbox 环境的使用以及验收](https://pay.weixin.qq.com/wiki/doc/api/jsapi.php?chapter=23_1)
    * 用法 

        ```
        # 获取 sandbox api_key ：
        WechatPay::Config.sandbox = false # 在 production 环境下执行
        sandbox_api_key = WechatPay::Signature::get_sandbox_key_from_api
        
        # 使用 
        WechatPay::Config.sandbox_key  = sandbox_api_key
        WechatPay::Config.sandbox = true
        ```

* 其他的一些修改
    * 通过 WechatPay::Config.http_headers 可以配置 api 通讯的时候的 user-agent 等 headers
    * 解决了 StandardError#initialize 初始化时的错误
    * 增加了 Respond#validate! 用来判断 xml 内的 return_code 和 result_code
    * 将 md5 sign 改成了大写
    * 指定了 http gem 的最低版本